### PR TITLE
feat: add meria validator infos

### DIFF
--- a/testnet-2/026d1ca45da1f5b3391da77a61ceadae3de52e2c405565a9744ad3abb8245c8967.json
+++ b/testnet-2/026d1ca45da1f5b3391da77a61ceadae3de52e2c405565a9744ad3abb8245c8967.json
@@ -1,0 +1,9 @@
+{
+  "name": "Meria",
+  "secp": "026d1ca45da1f5b3391da77a61ceadae3de52e2c405565a9744ad3abb8245c8967",
+  "bls": "8b95d78abe9c699477f76a352d10adfac2aa470a5d8b277a2d4a1b81d40ccb06d8779cb6c01c2ff24cf741a6861b386d",
+  "website": "https://www.meria.com/",
+  "description": "French Crypto Investment Provider",
+  "logo": "https://s3.amazonaws.com/keybase_processed_uploads/3fcc4caebb2c8e949829a7b090be3805_360_360.jpg",
+  "x": "https://x.com/Meria_Finance"
+}


### PR DESCRIPTION
add meria infos for monad github

The file should be named `<SECP_KEY>.json`

All keys can be found on the node by typing :

grep "public key" <KEY_BACKUP_LOCATION>