### PR TITLE
DELIGHT - Prevent symbol cropping in circular frames

### DIFF
--- a/testnet-2/0322b40febf89fa3cf6a05e9bbd8904b1979a0e43814d92de43ecdf81408037423.json
+++ b/testnet-2/0322b40febf89fa3cf6a05e9bbd8904b1979a0e43814d92de43ecdf81408037423.json
@@ -4,6 +4,6 @@
   "bls": "a2fc035404d21b3d36bc3645c3ffef455ce88097e239383d3d7cead84b00a311ce1165279ba8f73179d22f75d6ae570c",
   "website": "https://delightlabs.io",
   "description": "Technology-driven team contributing to a decentralized ecosystem",
-  "logo": "https://storage.delightlabs.io/images/DELIGHTLABS-Symbol.png",
+  "logo": "https://storage.delightlabs.io/images/DELIGHTLABS-Symbol-10px.png",
   "x": "https://x.com/delightlabs_io"
 }


### PR DESCRIPTION
This commit replaces the symbol used in circular frames with a version that has more padding, resolving an issue where the logo's corners were being cut off.