### PR TITLE
Update and rename ASXN Validator info

### DIFF
--- a/testnet-2/03fd7285bf5ad1216bbe7bfd28eea913f9f73f3d90c3b0bf2890cbfbf3cd2c40f1
+++ b/testnet-2/03fd7285bf5ad1216bbe7bfd28eea913f9f73f3d90c3b0bf2890cbfbf3cd2c40f1
@@ -1,7 +1,7 @@
 {
   "name": "ASXN",
-  "secp": "02a56ca2ae0ea319781ea7dcfe2af394eb6180533b566f0ae83d7ad87f8a8216fa",
-  "bls": "942d7a613e6c70da58db9dcebea9204d44c7796441d2f8281e218dd0e7be384a8394c343781db14c1c9a36c3115b0aee",
+  "secp": "03fd7285bf5ad1216bbe7bfd28eea913f9f73f3d90c3b0bf2890cbfbf3cd2c40f1",
+  "bls": "a7cdad5766c6614601d330667785f69babd7a527cd432b807ab991614f7c1b63c5388303e9512641a698bf07c3407ae5",
   "website": "https://asxn.xyz/",
   "description": "Boutique Digital Assets Research, Infrastructure and Validators.",
   "logo": "https://raw.githubusercontent.com/asxnres/brand_assets/refs/heads/main/logo_16in16in.png",


### PR DESCRIPTION
Hi

Updated details for testnet2. So that explorers like gmonad and hoodscan can show correctly.

On activation of staking module needed to create new secp and bls keys. This is latest

Thanks