### PR TITLE
chore(testnet-2): update quicknode secp and bls public keys

### DIFF
--- a/testnet-2/0205c0049ab521cf2d04aa2befd01346fb08ccc6652648d65704120270f91f2adb.json
+++ b/testnet-2/0205c0049ab521cf2d04aa2befd01346fb08ccc6652648d65704120270f91f2adb.json
@@ -1,7 +1,7 @@
 {
   "name": "QuickNode",
-  "secp": "02171634492697b70f5d017f564ceaedc1f3c307605637f8a3b97a5a2ac4895470",
-  "bls": "a8eab5e0ed8a028e1ac17fcee0e7ab58acff73c3723b4da50a349f5397a3a79612afd29b4a98b7042d377d3f2930434b",
+  "secp": "0205c0049ab521cf2d04aa2befd01346fb08ccc6652648d65704120270f91f2adb",
+  "bls": "b65b7f8c1bfc5f023409bacc3d40c551bc636c510e4ed1f1263d6e1d3b870e46a68903f3155633f1baf34d06ffa3ab07",
   "website": "https://www.quicknode.com/",
   "description": "🚀 Accelerating Web3 with lightning-fast Monad infrastructure ⚡ 🔐 SOC 1 Type 2, SOC 2 Type 2, ISO 27001 Certified.",
   "logo": "https://images.ctfassets.net/23fkqdsgbpuj/38cMM0iG1aD1GgCrBZUIEP/d740b7e96e13871296f8041e97f7d627/isolated-color.png",


### PR DESCRIPTION
This change is required, since we had to generate a new set of keys and add the validator again.