### PR TITLE
feat: add validator anril-1 (ID 262)

### DIFF
--- a/testnet/024028e1910c32cac434c75d34e6957f059d5642b07de92735efb92b7e73f6aabf.json
+++ b/testnet/024028e1910c32cac434c75d34e6957f059d5642b07de92735efb92b7e73f6aabf.json
@@ -1,0 +1,9 @@
+{
+  "id": 262,
+  "name": "anril-1",
+  "secp": "024028e1910c32cac434c75d34e6957f059d5642b07de92735efb92b7e73f6aabf",
+  "bls": "90b6b15a708aa6258622911b6cb4467918888f9943cb8141143a41094097578014318678fe56b0d2744fab6d617c93c8",
+  "website": "https://t.me/Anril44",
+  "description": "blockchain developer",
+  "x": "https://x.com/AnRil44"
+}


### PR DESCRIPTION
## Summary
- Add validator info for anril-1 (ID 262) to testnet directory

## Validator Details
- **ID**: 262
- **Name**: anril-1
- **SECP Key**: 024028e1910c32cac434c75d34e6957f059d5642b07de92735efb92b7e73f6aabf
- **BLS Key**: 90b6b15a708aa6258622911b6cb4467918888f9943cb8141143a41094097578014318678fe56b0d2744fab6d617c93c8

🤖 Generated with [Claude Code](https://claude.com/claude-code)