### PR TITLE
Add Endacoder validator configuration JSON file

### DIFF
--- a/testnet/02b49e9a3ddb6437b0c46d587e8023ef1ef519ed6ade62fd82ff502e02f0c85a18.json
+++ b/testnet/02b49e9a3ddb6437b0c46d587e8023ef1ef519ed6ade62fd82ff502e02f0c85a18.json
@@ -3,8 +3,8 @@
   "name": "Endacoder",
   "secp": "02b49e9a3ddb6437b0c46d587e8023ef1ef519ed6ade62fd82ff502e02f0c85a18",
   "bls": "b990ee9c7d295836c9a7025a99786f2fe72da3e87ce132e891b10a54e09d733e266ab06da50832e5caaf29b336f0315b",
-  "website": "",
+  "website": "https://endacoder.com/",
   "description": "Infrastructure validator (APAC)",
-  "logo": "",
+  "logo": "https://avatars.githubusercontent.com/u/241695680?s=400&u=b7ff05e71037372769c549c33f24498f7c5106c1&v=4",
   "x": ""
 }

--- a/testnet/02b49e9a3ddb6437b0c46d587e8023ef1ef519ed6ade62fd82ff502e02f0c85a18.json
+++ b/testnet/02b49e9a3ddb6437b0c46d587e8023ef1ef519ed6ade62fd82ff502e02f0c85a18.json
@@ -1,0 +1,10 @@
+{
+  "id": 265,
+  "name": "Endacoder",
+  "secp": "02b49e9a3ddb6437b0c46d587e8023ef1ef519ed6ade62fd82ff502e02f0c85a18",
+  "bls": "b990ee9c7d295836c9a7025a99786f2fe72da3e87ce132e891b10a54e09d733e266ab06da50832e5caaf29b336f0315b",
+  "website": "",
+  "description": "Infrastructure validator (APAC)",
+  "logo": "",
+  "x": ""
+}


### PR DESCRIPTION
This pull request adds a new validator entry to the testnet configuration. The change introduces a new JSON file describing the validator "Endacoder," including its keys and metadata.

Validator addition:
* Added a new validator configuration file `testnet/02b49e9a3ddb6437b0c46d587e8023ef1ef519ed6ade62fd82ff502e02f0c85a18.json` for the "Endacoder" infrastructure validator, specifying its `secp` and `bls` keys, description, and other metadata.