### PR TITLE
Add shadowoftime testnet validator (id 267)

### DIFF
--- a/testnet/029337dc788d1dd262280524a47cefa68b7ea5651016279b54cc20305a2e1aa7b6.json
+++ b/testnet/029337dc788d1dd262280524a47cefa68b7ea5651016279b54cc20305a2e1aa7b6.json
@@ -1,0 +1,10 @@
+{
+  "id": 267,
+  "name": "shadowoftime",
+  "secp": "029337dc788d1dd262280524a47cefa68b7ea5651016279b54cc20305a2e1aa7b6",
+  "bls": "86902ce27a2bf311007e3b625243c37d52dc4a06ca96a394781408b043fea8a108ffd5167602f9c13e2e2fb27a7b7e21",
+  "website": "https://shadowoftime1.github.io",
+  "description": "Independent validator with 7+ years blockchain ops experience. Running Monad testnet on bare metal; maintainer of MonadPulse analytics (monadpulse.xyz). Vanilla client, proactive upgrades.",
+  "logo": "https://shadowoftime1.github.io/favicon.svg",
+  "x": "https://x.com/RomanKarpenk"
+}


### PR DESCRIPTION
## Summary
- Register `shadowoftime` as a testnet validator (id `267`)
- Independent operator, running Monad on bare metal
- Maintainer of MonadPulse analytics — https://monadpulse.xyz

## Validator keys
- SECP: `029337dc788d1dd262280524a47cefa68b7ea5651016279b54cc20305a2e1aa7b6`
- BLS:  `86902ce27a2bf311007e3b625243c37d52dc4a06ca96a394781408b043fea8a108ffd5167602f9c13e2e2fb27a7b7e21`
- Auth EOA: `0x92936497B6ad2BA84b3f7Af22C9afF15f00b13B5`
- addValidator tx: `0x6aed41e0c64fbd7f5b6367b0e5c9831a75a122b65af078cc40922959dcbcbdd0` (block 26,037,683)

## Links
- Validator profile: https://shadowoftime1.github.io
- MonadPulse (analytics dashboard): https://monadpulse.xyz
- X: https://x.com/RomanKarpenk