### PR TITLE
Add shadowoftime (testnet id=267)

### DIFF
--- a/testnet/029337dc788d1dd262280524a47cefa68b7ea5651016279b54cc20305a2e1aa7b6.json
+++ b/testnet/029337dc788d1dd262280524a47cefa68b7ea5651016279b54cc20305a2e1aa7b6.json
@@ -1,0 +1,10 @@
+{
+  "id": 267,
+  "name": "shadowoftime",
+  "secp": "029337dc788d1dd262280524a47cefa68b7ea5651016279b54cc20305a2e1aa7b6",
+  "bls": "86902ce27a2bf311007e3b625243c37d52dc4a06ca96a394781408b043fea8a108ffd5167602f9c13e2e2fb27a7b7e21",
+  "website": "https://shadowoftime1.github.io",
+  "description": "Independent Monad validator, Sydney, Australia. Operator of MonadPulse analytics (monadpulse.xyz).",
+  "logo": "https://github.com/ShadowOfTime1.png",
+  "x": "https://x.com/RomanKarpenk"
+}


### PR DESCRIPTION
## Validator info

- **Name**: shadowoftime
- **Network**: testnet
- **Validator ID**: 267
- **Auth address**: `0x92936497B6ad2BA84b3f7Af22C9afF15f00b13B5`
- **Website**: https://shadowoftime1.github.io
- **X**: https://x.com/RomanKarpenk

Independent Monad validator based in Sydney, Australia. Also operator of [MonadPulse](https://monadpulse.xyz) — independent analytics platform for the Monad network (validator performance, health scores, delegation graph, on-chain alerts).

## Validation

```
✅ JSON is valid
✅ Schema and types match
✅ Name is valid: 'shadowoftime'
✅ Logo is valid
✅ SECP key matches on-chain value
✅ BLS key matches on-chain value
✅ Filename matches secp key
```

Ran `scripts/validate.py` locally against testnet RPC — all checks green.