### PR TITLE
chore: add missing testnet validators and decommission stale validators

### DIFF
--- a/mainnet/021f68fac315a1b9e7258af85385b780e7a594819d7532015182a74b80442e71e6.json
+++ b/mainnet/021f68fac315a1b9e7258af85385b780e7a594819d7532015182a74b80442e71e6.json
@@ -1,6 +1,6 @@
 {
   "id": 62,
-  "name": "Forest Staking (decommissioned)",
+  "name": "Forest Staking",
   "secp": "021f68fac315a1b9e7258af85385b780e7a594819d7532015182a74b80442e71e6",
   "bls": "b987129ea2e19c737a40f84530683376d1c929b1b44d1bb57022aef4f4f4aefd359630a726c927774cc3474ba3ec73aa",
   "website": "https://foreststaking.com",
@@ -8,6 +8,6 @@
   "logo": "https://raw.githubusercontent.com/ForestStaking/Forest_Staking_Logo/refs/heads/main/Forest_Staking_Logo_main.jpg",
   "x": "https://x.com/foreststaking",
   "registration_date": "2025-11-06",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/mainnet/02be8ad9e24e8961371832962c09c6948930d927b598f476ceccf1987a27988834.json
+++ b/mainnet/02be8ad9e24e8961371832962c09c6948930d927b598f476ceccf1987a27988834.json
@@ -8,6 +8,6 @@
   "logo": "https://raw.githubusercontent.com/ForestStaking/Forest_Staking_Logo/refs/heads/main/Forest_Staking_Logo_main.jpg",
   "x": "https://x.com/foreststaking",
   "registration_date": "2025-11-06",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/mainnet/02be8ad9e24e8961371832962c09c6948930d927b598f476ceccf1987a27988834.json
+++ b/mainnet/02be8ad9e24e8961371832962c09c6948930d927b598f476ceccf1987a27988834.json
@@ -8,6 +8,6 @@
   "logo": "https://raw.githubusercontent.com/ForestStaking/Forest_Staking_Logo/refs/heads/main/Forest_Staking_Logo_main.jpg",
   "x": "https://x.com/foreststaking",
   "registration_date": "2025-11-06",
-  "decommissioned": true,
+  "decommissioned": false,
   "vdp": true
 }

--- a/mainnet/02f49ae15431ca9d6ce440bc90525893f696983a722d00a9a94a21649b6e6ecde7.json
+++ b/mainnet/02f49ae15431ca9d6ce440bc90525893f696983a722d00a9a94a21649b6e6ecde7.json
@@ -8,6 +8,6 @@
   "logo": "https://assets.zellic.io/pfp.jpg",
   "x": "https://x.com/zellic_io",
   "registration_date": "2025-11-20",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/mainnet/0347967f3ecab6a70429374bc8339d81c4615d49cec1243b5d17927def66750373.json
+++ b/mainnet/0347967f3ecab6a70429374bc8339d81c4615d49cec1243b5d17927def66750373.json
@@ -8,6 +8,6 @@
   "logo": "https://hosted-assets-container-pbmv.s3.ca-central-1.amazonaws.com/NTT_DOCOMO_GLOBAL.png",
   "x": "https://x.com/nttdigital_io",
   "registration_date": "2025-07-22",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/mainnet/03b99d4e7efd4e06b762250644a14cc50eb54679c4e9aa3c401b3dc328c128a9b5.json
+++ b/mainnet/03b99d4e7efd4e06b762250644a14cc50eb54679c4e9aa3c401b3dc328c128a9b5.json
@@ -8,6 +8,6 @@
   "logo": "https://raw.githubusercontent.com/fsc-platform/blockchain-logos/main/flipside_icon.png",
   "x": "https://x.com/flipsidecrypto",
   "registration_date": "2025-07-31",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/mainnet/03cbbe1cfdd4f92712e9921c2bfecdf5ab1041436d799e5d96c4a407326cb2cf0f.json
+++ b/mainnet/03cbbe1cfdd4f92712e9921c2bfecdf5ab1041436d799e5d96c4a407326cb2cf0f.json
@@ -8,6 +8,6 @@
   "logo": "https://avatars.githubusercontent.com/u/226050113",
   "x": "https://x.com/ShavetheMFwhale",
   "registration_date": "2025-11-13",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -140,7 +140,7 @@ def main():
 
     # --- Check: 'logo' must point to a valid image URL (optional) ---
     logo = data.get("logo")
-    if logo is not None:
+    if logo is not None and logo != "":
         if check_logo(logo):
             print("✅ Logo is valid")
         else:

--- a/testnet/026586133c36830cf7ba7cbe7213e6fc11d435419af6d87f5355fb76070d1b278f.json
+++ b/testnet/026586133c36830cf7ba7cbe7213e6fc11d435419af6d87f5355fb76070d1b278f.json
@@ -8,6 +8,6 @@
   "logo": "https://assets.zellic.io/pfp.jpg",
   "x": "https://x.com/zellic_io",
   "registration_date": "2025-12-18",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/testnet/02b49e9a3ddb6437b0c46d587e8023ef1ef519ed6ade62fd82ff502e02f0c85a18.json
+++ b/testnet/02b49e9a3ddb6437b0c46d587e8023ef1ef519ed6ade62fd82ff502e02f0c85a18.json
@@ -1,0 +1,13 @@
+{
+  "id": 265,
+  "name": "02b49e9a3ddb6437b0c46d587e8023ef1ef519ed6ade62fd82ff502e02f0c85a18",
+  "secp": "02b49e9a3ddb6437b0c46d587e8023ef1ef519ed6ade62fd82ff502e02f0c85a18",
+  "bls": "b990ee9c7d295836c9a7025a99786f2fe72da3e87ce132e891b10a54e09d733e266ab06da50832e5caaf29b336f0315b",
+  "website": "",
+  "description": "",
+  "logo": "",
+  "x": "",
+  "registration_date": "2026-06-29",
+  "decommissioned": false,
+  "vdp": false
+}

--- a/testnet/02b9697a0de8b76f66aa22fab7d7a4079c3ea72b754e6ec5c5d2c068e2de2b91a9.json
+++ b/testnet/02b9697a0de8b76f66aa22fab7d7a4079c3ea72b754e6ec5c5d2c068e2de2b91a9.json
@@ -1,0 +1,13 @@
+{
+  "id": 218,
+  "name": "02b9697a0de8b76f66aa22fab7d7a4079c3ea72b754e6ec5c5d2c068e2de2b91a9",
+  "secp": "02b9697a0de8b76f66aa22fab7d7a4079c3ea72b754e6ec5c5d2c068e2de2b91a9",
+  "bls": "8063d22338620df3408618e3460d41c8a349240fcbb480dd2a2cbf1a1e9f92ba1ce8c41ed05a16357c7e848968b42619",
+  "website": "",
+  "description": "",
+  "logo": "",
+  "x": "",
+  "registration_date": "2026-06-29",
+  "decommissioned": false,
+  "vdp": false
+}

--- a/testnet/03e21de59a05302d5270c2ed21ac871198a4fdd9784c9daaf146dd8200e1c900ac.json
+++ b/testnet/03e21de59a05302d5270c2ed21ac871198a4fdd9784c9daaf146dd8200e1c900ac.json
@@ -1,6 +1,6 @@
 {
   "id": 261,
-  "name": "03e21de59a05302d5270c2ed21ac871198a4fdd9784c9daaf146dd8200e1c900ac",
+  "name": "Shark Labs",
   "secp": "03e21de59a05302d5270c2ed21ac871198a4fdd9784c9daaf146dd8200e1c900ac",
   "bls": "94b971e05525e71137215dd9725df5649f9cda82509dafcb7a51668401d35e56d6980199e8dc3f0150805ce7208b12f2",
   "website": "",

--- a/testnet/03e21de59a05302d5270c2ed21ac871198a4fdd9784c9daaf146dd8200e1c900ac.json
+++ b/testnet/03e21de59a05302d5270c2ed21ac871198a4fdd9784c9daaf146dd8200e1c900ac.json
@@ -1,0 +1,13 @@
+{
+  "id": 261,
+  "name": "03e21de59a05302d5270c2ed21ac871198a4fdd9784c9daaf146dd8200e1c900ac",
+  "secp": "03e21de59a05302d5270c2ed21ac871198a4fdd9784c9daaf146dd8200e1c900ac",
+  "bls": "94b971e05525e71137215dd9725df5649f9cda82509dafcb7a51668401d35e56d6980199e8dc3f0150805ce7208b12f2",
+  "website": "",
+  "description": "",
+  "logo": "",
+  "x": "",
+  "registration_date": "2026-06-29",
+  "decommissioned": false,
+  "vdp": false
+}

--- a/testnet/03f33ed6ae1c6b5bf54590ab0b1e42ad3217d2fc87e5dfd19b466d5c262c4b4254.json
+++ b/testnet/03f33ed6ae1c6b5bf54590ab0b1e42ad3217d2fc87e5dfd19b466d5c262c4b4254.json
@@ -1,0 +1,13 @@
+{
+  "id": 270,
+  "name": "03f33ed6ae1c6b5bf54590ab0b1e42ad3217d2fc87e5dfd19b466d5c262c4b4254",
+  "secp": "03f33ed6ae1c6b5bf54590ab0b1e42ad3217d2fc87e5dfd19b466d5c262c4b4254",
+  "bls": "ad03585efec80d8fcfcbc0472dfbce010748f4a6a85fea9f97e8e401eb4bf8f3990b6c46beaf451abbc87689faaeb7de",
+  "website": "",
+  "description": "",
+  "logo": "",
+  "x": "",
+  "registration_date": "2026-06-29",
+  "decommissioned": false,
+  "vdp": false
+}


### PR DESCRIPTION
This PR includes validator record updates across testnet and mainnet.

- Add 4 missing testnet validator records (stub entries with secp key as name, bls populated from live data)
- Decommission Zellic on both testnet and mainnet
- Decommission Flipside Crypto, vldtr.xyz, Forest Staking, and NTT DOCOMO GLOBAL on mainnet