### PR TITLE
chore(mainnet): set vdp=false for Jichu and smallstreet

### DIFF
--- a/mainnet/03b350c892d0307f3c7a9a6812c0d9a0e0ce53552121550429623c7bd5baa2297a.json
+++ b/mainnet/03b350c892d0307f3c7a9a6812c0d9a0e0ce53552121550429623c7bd5baa2297a.json
@@ -9,5 +9,5 @@
   "x": "https://x.com/jichu_xyz",
   "registration_date": "2026-05-28",
   "decommissioned": false,
-  "vdp": true
+  "vdp": false
 }

--- a/mainnet/03e8a5c0de95c8f031cf61d4385aca7a49f1450c121ce84056851914add4ec199f.json
+++ b/mainnet/03e8a5c0de95c8f031cf61d4385aca7a49f1450c121ce84056851914add4ec199f.json
@@ -9,5 +9,5 @@
   "x": "https://x.com/chamonster",
   "registration_date": "2026-02-12",
   "decommissioned": false,
-  "vdp": true
+  "vdp": false
 }


### PR DESCRIPTION
This PR implements a VDP flag correction for two mainnet validators.

- Set `vdp=false` for Jichu
- Set `vdp=false` for smallstreet