### PR TITLE
chore(testnet): decommission NTT DOCOMO GLOBAL and Flipside Crypto

### DIFF
--- a/testnet/0237a8f642e93c182c10d9c28e42efb12893f99847a7c458a0a70c6e3730216dff.json
+++ b/testnet/0237a8f642e93c182c10d9c28e42efb12893f99847a7c458a0a70c6e3730216dff.json
@@ -8,6 +8,6 @@
   "logo": "https://hosted-assets-container-pbmv.s3.ca-central-1.amazonaws.com/NTT_DOCOMO_GLOBAL.png",
   "x": "https://x.com/nttdigital_io",
   "registration_date": "2025-12-18",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/testnet/0391518f005435ce2f4378cbf7cc3c3ae18a285f1320f4a53223a9b1e60cdf72fc.json
+++ b/testnet/0391518f005435ce2f4378cbf7cc3c3ae18a285f1320f4a53223a9b1e60cdf72fc.json
@@ -8,6 +8,6 @@
   "logo": "https://raw.githubusercontent.com/fsc-platform/blockchain-logos/main/flipside_icon.png",
   "x": "https://x.com/flipsidecrypto",
   "registration_date": "2025-07-31",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }


### PR DESCRIPTION
This PR implements decommission flag updates on testnet.

- Set `decommissioned=true` for NTT DOCOMO GLOBAL on testnet
- Set `decommissioned=true` for Flipside Crypto on testnet