### PR TITLE
chore(testnet): decommission StakeAngle

### DIFF
--- a/testnet/03c14560d143e6ecc9f0bfd54022e5915fc7a00db205395aae1a047a9444179f33.json
+++ b/testnet/03c14560d143e6ecc9f0bfd54022e5915fc7a00db205395aae1a047a9444179f33.json
@@ -8,6 +8,6 @@
   "logo": "https://stakeangle.com/StakeAngle_logo.png",
   "x": "https://x.com/Muster365",
   "registration_date": "2025-11-11",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }


### PR DESCRIPTION
This PR decommissions the StakeAngle testnet validator.

- Sets `decommissioned: true` for StakeAngle (`03c14560...`)