### PR TITLE
chore: decommission SOL Strategies and Cosmostation validators

### DIFF
--- a/mainnet/020725ea4d9c56d7f0f798599c59682d1cfc6b667916946645d5887d5225c76733.json
+++ b/mainnet/020725ea4d9c56d7f0f798599c59682d1cfc6b667916946645d5887d5225c76733.json
@@ -8,6 +8,6 @@
   "logo": "https://img.solstrategies.io/cogent.jpg",
   "x": "https://x.com/Cogent_Crypto",
   "registration_date": "2025-09-23",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/mainnet/03dd68922e5a4b8da8f999d76c104647ae29a04289d3c1cc85db201e103998cc3e.json
+++ b/mainnet/03dd68922e5a4b8da8f999d76c104647ae29a04289d3c1cc85db201e103998cc3e.json
@@ -8,6 +8,6 @@
   "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/4deea8224437cdff96dc588d1671bd63b3cff1f3/resource/cosmostation/cosmostation_black_bg(256x256).png",
   "x": "https://x.com/cosmostationvd",
   "registration_date": "2025-11-11",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/mainnet/03ff39df45b74dc0b1623e0065db8e6ff0a79a06c9afd72a75ccefd739604db5dc.json
+++ b/mainnet/03ff39df45b74dc0b1623e0065db8e6ff0a79a06c9afd72a75ccefd739604db5dc.json
@@ -7,6 +7,6 @@
   "description": "High performance validator by SOL Strategies. ISO27001 & SOC2 Type I certified",
   "x": "https://x.com/laine_sa_",
   "registration_date": "2025-09-23",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/testnet/0221a2de693145e577ec668ace10b925f51882f681816685659dfb7579930a40eb.json
+++ b/testnet/0221a2de693145e577ec668ace10b925f51882f681816685659dfb7579930a40eb.json
@@ -8,6 +8,6 @@
   "logo": "https://img.solstrategies.io/cogent.jpg",
   "x": "https://x.com/Cogent_Crypto",
   "registration_date": "2025-09-23",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/testnet/03052cba6a48b26e62e631d46d89664b2993a1d943bffc6bb9442b43a17133b51c.json
+++ b/testnet/03052cba6a48b26e62e631d46d89664b2993a1d943bffc6bb9442b43a17133b51c.json
@@ -7,6 +7,6 @@
   "description": "High performance validator by SOL Strategies. ISO27001 & SOC2 Type I certified",
   "x": "https://x.com/laine_sa_",
   "registration_date": "2025-09-23",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/testnet/035e05885785ba73b53634657fd04b12fc3aa737aa17041579a16c968fdbeb1a0f.json
+++ b/testnet/035e05885785ba73b53634657fd04b12fc3aa737aa17041579a16c968fdbeb1a0f.json
@@ -8,6 +8,6 @@
   "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/4deea8224437cdff96dc588d1671bd63b3cff1f3/resource/cosmostation/cosmostation_black_bg(256x256).png",
   "x": "https://x.com/CosmostationVD",
   "registration_date": "2025-07-15",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }


### PR DESCRIPTION
This PR decommissions SOL Strategies (Cogent and Laine) and Cosmostation validators across mainnet and testnet.

- Mark `Cogent ⚙️  by SOL Strategies` (mainnet) as decommissioned
- Mark `Laine ❤️ by SOL Strategies` (mainnet) as decommissioned
- Mark `Cogent ⚙️  by SOL Strategies` (testnet) as decommissioned
- Mark `Laine ❤️ by SOL Strategies` (testnet) as decommissioned
- Mark `Cosmostation` (mainnet) as decommissioned
- Mark `Cosmostation` (testnet) as decommissioned