### PR TITLE
chore(testnet): update InfStones validator info

### DIFF
--- a/testnet/0235a74e1b55cbcef556dc2b6f30e872a86aa2ac027b5339992abc443ad70b4a8a.json
+++ b/testnet/0235a74e1b55cbcef556dc2b6f30e872a86aa2ac027b5339992abc443ad70b4a8a.json
@@ -1,11 +1,12 @@
 {
   "id": 176,
-  "name": "0235a74e1b55cbcef556dc2b6f30e872a86aa2ac027b5339992abc443ad70b4a8a",
+  "name": "InfStones",
   "secp": "0235a74e1b55cbcef556dc2b6f30e872a86aa2ac027b5339992abc443ad70b4a8a",
   "bls": "a827028dcf64f45e6fa09d7370f01f9c507ac200eb71388599d0f54979b1015dc2708b1ee5bab2dd6e844197922a734a",
-  "website": "",
-  "description": "",
-  "x": "",
+  "website": "https://infstones.com/",
+  "description": "The Ultimate Blockchain Infrastructure Services Platform",
+  "logo": "https://infstones.com/assets/icons/footer_logo.svg",
+  "x": "https://x.com/InfStones",
   "registration_date": "2025-07-15",
   "decommissioned": false,
   "vdp": true


### PR DESCRIPTION
This PR implements a sync of the InfStones validator info from mainnet to the corresponding testnet node.

- Updates `name` from the raw pubkey to "InfStones"
- Adds `website`, `description`, and `x` links matching the mainnet entry
- Adds `logo` field
- Preserves testnet-specific `id`, `secp`, `bls`, and `registration_date`