### PR TITLE
Update validator 11 metadata: Pier Two -> MAVAN

### DIFF
--- a/mainnet/038c5b6ebb7ad2842c2498ca5ca6da348459b259f7d86fad940f13a7bb43ce7325.json
+++ b/mainnet/038c5b6ebb7ad2842c2498ca5ca6da348459b259f7d86fad940f13a7bb43ce7325.json
@@ -1,12 +1,12 @@
 {
   "id": 11,
-  "name": "Pier Two",
+  "name": "MAVAN",
   "secp": "038c5b6ebb7ad2842c2498ca5ca6da348459b259f7d86fad940f13a7bb43ce7325",
   "bls": "b3b5a44a91360b67a1dcc4e022f3bbf4231a5eb6ff442f936252ac509fdd8a99681becdb5564f050e1388c05b8f28371",
-  "website": "https://piertwo.com/",
-  "description": "Established in 2018, Pier Two is an Australian-based, APAC-focused institutional staking provider. Operating highly performant hybrid cloud and bare metal infrastructure, with zonal redundancy.",
-  "logo": "https://avatars.githubusercontent.com/u/125952310",
-  "x": "https://x.com/PierTwo_com",
+  "website": "https://www.bitminetech.io/",
+  "description": "MAVAN is the largest single staking operation in the world, providing institutional-grade non-custodial staking services. MAVAN is a Bitmine Immersion Technologies, Inc. (NYSE: BMNR) company.",
+  "logo": "https://app.mavan.bitminetech.io/img/logo/MAVAN_Logomark_White_Eagle_512.png",
+  "x": "https://x.com/BitMNR",
   "registration_date": "2025-11-10",
   "decommissioned": false,
   "vdp": true


### PR DESCRIPTION
Rebrand of validator ID 11 (secp `038c5b6e…ce7325`) from Pier Two to MAVAN.

- name: Pier Two → MAVAN
- website → https://www.bitminetech.io/
- description → MAVAN institutional-staking blurb (matches our on-chain Solana validator-info verbatim)
- logo → MAVAN logomark (bitminetech.io-hosted)
- x → https://x.com/BitMNR

Keys (secp/bls), id, registration_date, decommissioned, and vdp are unchanged.