### PR TITLE
Update validator 163 (testnet) metadata: Pier Two -> MAVAN

### DIFF
--- a/testnet/024c7809eaec64f03d1799dba942436cc932a1b1c4d7ed2a9dd6598d5ecd129855.json
+++ b/testnet/024c7809eaec64f03d1799dba942436cc932a1b1c4d7ed2a9dd6598d5ecd129855.json
@@ -1,12 +1,12 @@
 {
   "id": 163,
-  "name": "Pier Two",
+  "name": "MAVAN",
   "secp": "024c7809eaec64f03d1799dba942436cc932a1b1c4d7ed2a9dd6598d5ecd129855",
   "bls": "a552c1ad14cbbe796812385c04ab5adc4a83a23333a4658e908b414b043a3d788bd8afd93e33fada734d941102c16c8b",
-  "website": "https://piertwo.com/",
-  "description": "Pier Two is an Institutional staking services provider, established in Australia, in 2018. With multi-zonal 24/7 operations, high-performance hybrid cloud and bare metal infrastructure. Pier Two serves as a strategic partner in achieving sustainable staking rewards and growth, while helping protocol security.",
-  "logo": "https://piertwo.com/img/brand-assets/logo/logomark-midblue.svg",
-  "x": "https://x.com/piertwo_com",
+  "website": "https://www.bitminetech.io/",
+  "description": "MAVAN is the largest single staking operation in the world, providing institutional-grade non-custodial staking services. MAVAN is a Bitmine Immersion Technologies, Inc. (NYSE: BMNR) company.",
+  "logo": "https://app.mavan.bitminetech.io/img/logo/MAVAN_Logomark_White_Eagle_512.png",
+  "x": "https://x.com/BitMNR",
   "registration_date": "2025-12-18",
   "decommissioned": false,
   "vdp": true


### PR DESCRIPTION
Rebrand of testnet validator ID 163 (secp `024c7809…129855`) from Pier Two to MAVAN, mirroring the mainnet rebrand in #979.

- name: Pier Two → MAVAN
- website → https://www.bitminetech.io/
- description → MAVAN institutional-staking blurb
- logo → MAVAN logomark (bitminetech.io-hosted)
- x → https://x.com/BitMNR

Keys (secp/bls), id, registration_date, decommissioned, and vdp are unchanged.