### PR TITLE
Rekey MAVAN testnet validator: add id 277, decommission id 163

### DIFF
--- a/testnet/02140511ed2156a2c4b6561c08a5eaf0cf9d756e8fab5cde231a8653835d58da0a.json
+++ b/testnet/02140511ed2156a2c4b6561c08a5eaf0cf9d756e8fab5cde231a8653835d58da0a.json
@@ -1,13 +1,13 @@
 {
-  "id": 163,
+  "id": 277,
   "name": "MAVAN",
-  "secp": "024c7809eaec64f03d1799dba942436cc932a1b1c4d7ed2a9dd6598d5ecd129855",
-  "bls": "a552c1ad14cbbe796812385c04ab5adc4a83a23333a4658e908b414b043a3d788bd8afd93e33fada734d941102c16c8b",
+  "secp": "02140511ed2156a2c4b6561c08a5eaf0cf9d756e8fab5cde231a8653835d58da0a",
+  "bls": "a4d981eebe7fb6af8bd8cd490218bb3dae6777f135337d9c84885947d2660b01b8104eafe05702097c15c030e5e22443",
   "website": "https://www.bitminetech.io/",
   "description": "MAVAN is the largest single staking operation in the world, providing institutional-grade non-custodial staking services. MAVAN is a Bitmine Immersion Technologies, Inc. (NYSE: BMNR) company.",
   "logo": "https://app.mavan.bitminetech.io/img/logo/MAVAN_Logomark_White_Eagle_512.png",
   "x": "https://x.com/BitMNR",
-  "registration_date": "2025-12-18",
-  "decommissioned": true,
+  "registration_date": "2026-07-28",
+  "decommissioned": false,
   "vdp": true
 }


### PR DESCRIPTION
MAVAN testnet validator key rotation after a hardware rebuild. New validator id 277 (`02140511…`, bls `a4d981ee…`) registered on-chain; superseded id 163 (`024c7809…`) marked decommissioned. Same operator, node synced and running.