### PR TITLE
fix(testnet): rekey Xlabs validator, add id 278, decommission id 25

### DIFF
--- a/testnet/0233efded1145834851659145948bbc72764903fc34ab08cdaaeb2c939e3dc92cf.json
+++ b/testnet/0233efded1145834851659145948bbc72764903fc34ab08cdaaeb2c939e3dc92cf.json
@@ -8,6 +8,6 @@
   "logo": "https://xlabs.xyz/xlabs.png",
   "x": "https://x.com/xLabsxyz",
   "registration_date": "2025-12-16",
-  "decommissioned": false,
+  "decommissioned": true,
   "vdp": true
 }

--- a/testnet/0283dbf6d3e98e49769532b21c0ba1e0c661c753ce2278299eef6162418ac18522.json
+++ b/testnet/0283dbf6d3e98e49769532b21c0ba1e0c661c753ce2278299eef6162418ac18522.json
@@ -1,0 +1,13 @@
+{
+  "id": 278,
+  "name": "xLabs",
+  "secp": "0283dbf6d3e98e49769532b21c0ba1e0c661c753ce2278299eef6162418ac18522",
+  "bls": "b2b67090ec60ee6233032c5b0fbd66844cad2acd61f3c1b2801bdb013f6598e6f82fe35a2f5418d7c7181db073d8a74c",
+  "website": "https://xlabs.xyz",
+  "description": "Core infrastructure for the internet of value",
+  "logo": "https://xlabs.xyz/xlabs.png",
+  "x": "https://x.com/xLabsxyz",
+  "registration_date": "2026-08-03",
+  "decommissioned": false,
+  "vdp": true
+}


### PR DESCRIPTION
This PR implements a validator rekey for Xlabs on testnet.

- Adds new validator entry with id 278 for Xlabs, carrying over the same metadata (name, website, description, logo, x)
- Sets new secp/bls keys for the new validator entry
- Marks the old Xlabs validator (id 25) as decommissioned